### PR TITLE
HH-126546 add identifiers alphabet check, forbid 'org.jetbrains.annotations' imports

### DIFF
--- a/checks/pom.xml
+++ b/checks/pom.xml
@@ -63,19 +63,6 @@
                     <release>8</release>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/checkstyle-config-plugin/src/main/resources/shared-checkstyle.xml
+++ b/checkstyle-config-plugin/src/main/resources/shared-checkstyle.xml
@@ -16,7 +16,7 @@
         <module name="OneStatementPerLine"/>
         <module name="AvoidStarImport"/>
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="sun, ru.hh.hhid.abi_shaded, ru.hh.guice.hibernate, junit.framework, org.apache.log4j"/>
+            <property name="illegalPkgs" value="sun, ru.hh.hhid.abi_shaded, ru.hh.guice.hibernate, junit.framework, org.apache.log4j, org.jetbrains.annotations"/>
         </module>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
@@ -28,6 +28,9 @@
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
         </module>
         <module name="ParameterName"/>
+        <module name="IllegalIdentifierName">
+            <property name="format" value="^[a-zA-Z0-9_]+$"/>
+        </module>
         <module name="OuterTypeNumber"/>
         <module name="GenericWhitespace"/>
         <module name="MethodParamPad"/>

--- a/pom.xml
+++ b/pom.xml
@@ -43,8 +43,9 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
+                        <phase>verify</phase>
                         <goals>
-                            <goal>jar</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-126546

Добавил проверку, что идентификаторы должны состоять только из латинских букв, цифр и подчёркиваний.
Ещё добавил `org.jetbrains.annotations` в список запрещённых импортов.
